### PR TITLE
Handling base64 missing padding chars

### DIFF
--- a/tinytor.py
+++ b/tinytor.py
@@ -186,16 +186,11 @@ class Consensus:
                 tor_port = int(split_line[7])
                 dir_port = int(split_line[8])
 
-                while True:
-                    try:
-                        # The fingerprint here is base64 encoded bytes.
-                        # The descriptor URL uses the base16 encoded value of these bytes.
-                        # Documentation for this was hard to find...
-                        identity = b16encode(b64decode(identity.encode())).decode()
-                        break
-                    except binascii.Error:
-                        # Incorrect base64 padding.
-                        identity = identity + "="
+                # The fingerprint here is base64 encoded bytes.
+                # The descriptor URL uses the base16 encoded value of these bytes.
+                # Documentation for this was hard to find...
+                identity += '=' * (-len(identity) % 4)
+                identity = b16encode(b64decode(identity.encode())).decode()
 
                 onion_router = OnionRouter(nickname, ip, dir_port, tor_port, identity)
             elif line.startswith("s "):


### PR DESCRIPTION
I many places in the tor spec is said: 
> base64 encoded, without trailing =s.

So, if well this change address the problem with the fingerprint field, it would be a good idea to have an utility function called `decode_base64_without_padding` or something like that.