### PR TITLE
Updates: provide basic functionality for clear URL/IP request over Tor-circuit

### DIFF
--- a/tinytor.py
+++ b/tinytor.py
@@ -314,6 +314,7 @@ class CommandType:
     AUTH_CHALLENGE = 130
     AUTHENTICATE = 131
 
+class RelayCommand:
     # The relay commands.
     #
     # Within a circuit, the OP and the exit node use the contents of
@@ -410,7 +411,7 @@ class Cell:
             #     H_LEN      (Client Handshake Data Len) [2 bytes]
             #     H_DATA     (Client Handshake Data)     [H_LEN bytes]
             payload_bytes = struct.pack("!HH", self.payload["type"], self.payload["length"]) + self.payload["data"]
-        elif self.command == CommandType.RELAY_EARLY:
+        elif self.command in (CommandType.RELAY_EARLY, CommandType.RELAY):
             payload_bytes = self.payload["encrypted_payload"]
         else:
             log.error("Invalid payload format for command: " + str(self.command))
@@ -493,7 +494,7 @@ class RelayCell(Cell):
             "data": data
         }
 
-        if relay_command == CommandType.RELAY_EXTENDED2:
+        if relay_command == RelayCommand.RELAY_EXTENDED2:
             data_length = struct.unpack("!H", data[:2])[0]
             data = data[2:data_length + 2]
             y = data[:32]
@@ -501,6 +502,8 @@ class RelayCell(Cell):
 
             response_data["Y"] = y
             response_data["auth"] = auth
+        elif relay_command in (RelayCommand.RELAY_DATA, RelayCommand.RELAY_CONNECTED, RelayCommand.RELAY_END):
+            pass
         else:
             log.warning("Unsupported relay cell: %d", relay_command)
             return response_data

--- a/tinytor.py
+++ b/tinytor.py
@@ -126,6 +126,9 @@ class OnionRouter:
 
             if line.startswith("ntor-onion-key "):
                 self.key_ntor = line.split("ntor-onion-key")[1].strip()
+                if self.key_ntor[-1] != '=':
+                    # The trailing '=' sign MAY be omitted from the base64 encoding
+                    self.key_ntor += "="
                 break
 
     def set_shared_secret(self, data):

--- a/tinytor.py
+++ b/tinytor.py
@@ -31,6 +31,13 @@ try:
 except ImportError:
     # Python2 support.
     from urllib2 import Request, urlopen, HTTPError
+try:
+    # python3
+    from urllib.parse import urlparse
+except:
+    # python2
+    from urlparse import urlparse
+
 
 try:
     # Set up byte handling for python2.
@@ -1214,7 +1221,7 @@ class TinyTor:
 
                 guard_relay.parse_descriptor()
                 break
-            except HTTPError:
+            except Exception:
                 traceback.print_exc()
                 log.info("Retrying with a different guard relay...")
 
@@ -1247,22 +1254,31 @@ class TinyTor:
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument("--host", help="the onion service to reach", required=True)
+    #parser.add_argument("--host", help="the onion service to reach", required=True)
+    parser.add_argument("--host", help="the url to reach", required=True)
     parser.add_argument("--no-banner", help="prevent the TinyTor banner from being displayed", action="store_true")
     parser.add_argument("-v", "--verbose", help="enable verbose output", action="store_true")
 
     arguments = parser.parse_args()
 
+    parsed_host = urlparse(arguments.host).geturl()
     if not arguments.no_banner:
         print(BANNER)
-    if not arguments.host.endswith(".onion"):
-        log.error("Please specify a valid onion service (--host).")
+    # The onion services v2 and v3 implementations are needed for connections to .oinion-addresses.
+    # specs for hidden-services:
+    # https://gitweb.torproject.org/torspec.git/tree/rend-spec-v2.txt
+    # https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt
+    #if not arguments.host.endswith(".onion"):
+        #log.error("Please specify a valid onion service (--host).")
+        #exit(1)
+    if not parsed_host:
+        log.error("Please specify a valid url (--host).")
         exit(1)
     if arguments.verbose:
         log.setLevel(logging.DEBUG)
 
     tor = TinyTor()
-    print("Received response: \n%s" % tor.http_get(arguments.host))
+    print("Received response: \n%s" % tor.http_get(parsed_host))
 
 
 if __name__ == '__main__':

--- a/tinytor.py
+++ b/tinytor.py
@@ -471,14 +471,6 @@ class RelayCell(Cell):
     def __init__(self, cell):
         super().__init__(cell.circuit_id, cell.command, cell.payload["encrypted_payload"])
 
-    def decrypt(self, onion_routers):
-        """Decrypts the encrypted payload.
-
-        :type onion_routers: list[OnionRouter]
-        """
-        for router in reversed(onion_routers):
-            self.payload = router.decrypt(self.payload)
-
     def parse_cell(self):
         """Parses the relay cell.
 


### PR DESCRIPTION
In my tour to investigate and learn about the Tor algorithms I want to improve and provide features to this script.
I made changes to create a normal Tor-circuit of three hops and send http-Get requests to normal clear URL's. It is (currently) not possible to reach out to hidden-services (also known as onion-address), because is requires a lot of extra effort.
changes made:
- fix de-/en-cryption algorithms
- implement streams, used after the circuit is established 
- receive relay-data